### PR TITLE
Recipe: Blog (Markdown, collection & feed)

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -8,7 +8,7 @@ export const meta = {
 
 The San Blas Islands of Panama is an `archipelago` comprising approximately 365 islands and cays, of which 49 are inhabited. They lie off the north coast of the Isthmus of Panama, east of the Panama Canal. A part of the comarca (district) [Guna Yala](https://en.wikipedia.org/wiki/Guna_Yala) along the Caribbean coast of Panama is home to the Guna people.
 
-![A known image URL](https://commons.wikimedia.org/wiki/File:San_Blas_Islands.jpg)
+![A known image URL](https://upload.wikimedia.org/wikipedia/commons/0/0a/San_Blas_Islands.jpg)
 
 import image from '../images/island.jpg'
 
@@ -21,3 +21,14 @@ import image from '../images/island.jpg'
   - the densely crowded island village of Carti Sugtupu
   - and the two keys, Cayos Limones, and Cayos Holandeses, both renowned for their clear waters.
 - The islands could be rendered uninhabitable by sea level rise in the late 21st century.
+
+## Post archive
+
+<ul>
+  {props.posts.map(post => (
+    <li key={post.urlPath}>
+      <a href={post.urlPath}>{post.meta.title}</a>
+      <small>({post.meta.date})</small>
+    </li>
+  ))}
+</ul>

--- a/pages/my-first-post.mdx
+++ b/pages/my-first-post.mdx
@@ -1,0 +1,10 @@
+export const meta = {
+  title: 'My first post',
+  description: 'The first post in my San Blas-powered blog.',
+  date: '2019-08-30',
+  collection: 'posts'
+}
+
+Before the arrival of Europeans, the [Guna](https://en.wikipedia.org/wiki/Guna_people) wore few clothes and decorated their bodies with colorful designs. When encouraged to wear clothes by the missionaries, they copied these designs in their [molas](https://en.wikipedia.org/wiki/Mola_(art_form)), which they wore as clothing.
+
+The Guna worship a god named Erragon, whom they believe came and died just for the Guna people. Driven off Panama during the Spanish invasion, the Guna fled to the surrounding 378 islands. Today their chief lives on an island called Acuadup, which means "rock island". Many Guna are hunters and fishermen. On some of the islands, children can attend school. Most of the men now speak [Spanish](https://en.wikipedia.org/wiki/Spanish_language), although the women carry on older traditions. 

--- a/pages/my-second-post.mdx
+++ b/pages/my-second-post.mdx
@@ -1,0 +1,8 @@
+export const meta = {
+  title: 'My second post',
+  description: 'The second post in my San Blas-powered blog.',
+  date: '2019-09-30',
+  collection: 'posts'
+}
+
+From 1679 to 1681, [William Dampier](https://en.wikipedia.org/wiki/William_Dampier) started and ended his first journey with privateers and pirates in these islands which he called "The Samballoes," a rendezvous-place for pirates, convenient for hiding and privacy. 


### PR DESCRIPTION
By default, San Blas just renders pages that don't know anything about each other.

If you're building a blog you need 3 ingredients:

- Markdown (see #1) 
- Collections: we need to group our "posts" so we can do things with them as a group, like list them on our homepage
- Feeds: because you want people & robots to subscribe to your blog!

#1 showed how to add Markdown support. This PR extends that one, so read it & make those changes first. Then we'll...

- Add a couple of example blog posts, identifying them as posts by adding `collection: 'posts'` to their metadata
- Build all the post pages
- Show a list of all posts on the homepage
- Generate a [JSON Feed](https://jsonfeed.org/) `feed.json` file


